### PR TITLE
Update EmailDomainValidator.csproj properties and references

### DIFF
--- a/EmailDomainValidator/EmailDomainValidator.csproj
+++ b/EmailDomainValidator/EmailDomainValidator.csproj
@@ -1,21 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+	<TargetFramework>net9.0</TargetFramework>
+	<ImplicitUsings>enable</ImplicitUsings>
+	<Nullable>enable</Nullable>
     <PackageId>EmailDomainValidator</PackageId>
     <VersionPrefix>1.0.0</VersionPrefix>
     <Authors>John Kehinde</Authors>
     <Description>A .NET library to validate email addresses and detect disposable emails.</Description>
     <PackageTags>email, validation, disposable-email</PackageTags>
+	<PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
-  <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.2" />
+	<None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Added `<PackageReadmeFile>` to include `README.md` in the package.
- Consolidated `<PropertyGroup>` settings for target framework and nullability.
- Retained package references for Microsoft.Extensions libraries at version 9.0.2.
- Added `<None>` item to ensure `README.md` is included in the package output.