### PR TITLE
Add disposable_email_blocklist.conf to project

### DIFF
--- a/EmailDomainValidator/EmailDomainValidator.csproj
+++ b/EmailDomainValidator/EmailDomainValidator.csproj
@@ -19,4 +19,10 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.2" />
 	<None Include="..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
+
+  <ItemGroup>
+    <None Update="disposable_email_blocklist.conf">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Added a new `<ItemGroup>` in the project file to include the configuration file `disposable_email_blocklist.conf`. This file is configured to be copied to the output directory with the `PreserveNewest` option.