### PR TITLE
Update EmailDomainValidator.csproj for blocklist config

### DIFF
--- a/EmailDomainValidator/EmailDomainValidator.csproj
+++ b/EmailDomainValidator/EmailDomainValidator.csproj
@@ -10,6 +10,14 @@
     <PackageTags>email, validation, disposable-email</PackageTags>
 	<PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+  <ItemGroup>
+    <None Remove="disposable_email_blocklist.conf" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="disposable_email_blocklist.conf">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </EmbeddedResource>
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.3" />
@@ -18,11 +26,5 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="9.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.3" />
 	<None Include="..\README.md" Pack="true" PackagePath="\" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Update="disposable_email_blocklist.conf">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Removed previous configuration for `disposable_email_blocklist.conf` and added it as an embedded resource. This ensures the file is included in the output directory with the `PreserveNewest` option for access in the compiled assembly.