### PR TITLE
Remove disposable email domains configuration from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,20 +57,6 @@ else
 
 ---
 
-### **Configuration**
-Configure the list of disposable email domains in `appsettings.json`:
-```json
-{
-    "DisposableDomains": [
-        "mailinator.com",
-        "10minutemail.com",
-        "guerrillamail.com"
-    ]
-}
-```
-
----
-
 ### **Dependencies**
 - **Microsoft.Extensions.Caching.Memory**: For caching MX record lookups.
 - **System.Net.Http**: For making HTTP requests to third-party APIs.


### PR DESCRIPTION
This commit removes the section in README.md that provided configuration details for disposable email domains, including the JSON example for domains like "mailinator.com", "10minutemail.com", and "guerrillamail.com". The dependencies section remains unchanged.